### PR TITLE
switch to commonjs for main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "node/",
     "umd/"
   ],
-  "main": "index.js",
+  "main": "node/index.js",
   "module": "es/index.js",
   "esnext": "esnext/index.js",
   "scripts": {


### PR DESCRIPTION
<img width="700" alt="screen shot 2017-11-15 at 4 43 55 pm" src="https://user-images.githubusercontent.com/3924690/32864331-670e59e0-ca24-11e7-87ba-ae426dd93936.png">

Note: index.js did not exist, so this package could not be imported, unless you point your module bundler to a specific entry a la

```javascript
import css from 'yocss/es/index';
```

Not sure if commonjs is the way to go, or es, honestly! Let me know, and I'll switch it up